### PR TITLE
BMS Charging Soft Stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ With a somewhat rideable board under my feet, I wanted to get everything tuned n
 
 ## To-Do
 - Automatic power off via remote
-- BMS automatic re-enable after charge completion (must be power cycled before riding)
 - Button press CAN Bus functionality (button only turns on/off right now)
 - Overtemperature detection on Charge/Discharge MOSFETs
 


### PR DESCRIPTION
- Fix my lazy implementation of stopping charging. Updated code to check maximum cell voltage while charging and disable charging by clearing the charge enable flag on the BMS instead of using the over-voltage protection cutoff.
- Charging will re-enable when unplugged or the voltage drops below a threshold of 4.05V.
- Update LED pattern to show breathing red while charging is active, and breathing green when charging has been stopped